### PR TITLE
Add Ability To Set Cluster (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Calling `cluster()` before `finalize()` will make sure requests are sent to your
 let pusher = Pusher::new("id", "key", "secret").cluster("eu").finalize();
 ```
 
-This is not set by default. If set it will create a host like `api-eu.pusher.com`. If you also specify `host`, setting `cluster` will not have any effect.
+This is not set by default. If set it will create a host like `api-eu.pusher.com`. If you also specify `host`, setting `cluster` will overwrite it, and fall back to using the `pusher` api.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ let pusher = Pusher::new("id", "key", "secret").host("foo.bar.com").finalize();
 
 By default, this is `"api.pusherapp.com"`.
 
+#### Changing cluster
+
+Calling `cluster()` before `finalize()` will make sure requests are sent to your specified cluster.
+
+```rust
+let pusher = Pusher::new("id", "key", "secret").cluster("eu").finalize();
+```
+
+This is not set by default. If set it will create a host like `api-eu.pusher.com`. If you also specify `host`, setting `cluster` will not have any effect.
+
 ## Usage
 
 ### Triggering events


### PR DESCRIPTION
As we spoke about in #9 this PR will allow you to call `.cluster('eu')` when creating a pusher client.

I'm not sure if the client should do anything when you do something like `.host('api.host.com').cluster('eu')` as these operations will not work together - what do you think?